### PR TITLE
Removed sending universal skills

### DIFF
--- a/services/distributions_api/const.py
+++ b/services/distributions_api/const.py
@@ -6,4 +6,6 @@ TEMPLATE_DIST_PROMPT_BASED = {
 INVISIBLE_COMPONENT_NAMES = [
     "dialogpt",
     "dff_generative_skill",
+    "dff_universal_prompted_skill",
+    "dff_dream_persona_ru_prompted_skill",
 ]


### PR DESCRIPTION
PR covers task from Jira:
https://deeppavlov.atlassian.net/browse/DREAM-1701

Except for errors when cloning skills: “dream FAQ Skill”, “LangChain Google API Skill“. Must be edited in the database or edit configuration files in dream.
